### PR TITLE
feat: Allow content files to specify HTML layouts

### DIFF
--- a/content/hello.md
+++ b/content/hello.md
@@ -2,6 +2,7 @@
 title: "My First Terrific Post with Frontmatter!"
 date: "2025-05-26"
 author: "Dr. Terrific"
+layout: post.html
 tags: ["go", "ssg", "fun"]
 custom_greeting: "Hello from the frontmatter!"
 ---

--- a/internal/model/pagedata.go
+++ b/internal/model/pagedata.go
@@ -9,4 +9,5 @@ type PageData struct {
 	BaseURL   string
 	Date      string
 	Params    map[string]interface{}
+	Layout    string // New field for specifying the layout
 }

--- a/layouts/post.html
+++ b/layouts/post.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ .PageTitle }} | {{ .SiteTitle }}</title>
+    <link rel="stylesheet" href="{{ .BaseURL }}/css/style.css">
+</head>
+<body>
+    <div class="container">
+        {{ template "header.html" . }} <main>
+            <p><em>--- This page is using the 'post.html' layout ---</em></p>
+            {{ .Content }}
+        </main>
+
+        {{ template "footer.html" . }} </div>
+</body>
+</html>


### PR DESCRIPTION
This commit introduces the ability for individual content pages to specify which HTML layout file should be used for rendering, instead of defaulting to base.html for all pages.

Key changes:
- Added a `Layout` field to the `PageData` struct in `internal/model/pagedata.go`.
- Modified `cmd/build.go` to:
    - Read a `layout` key from the frontmatter of markdown files.
    - Populate the `PageData.Layout` field with this value.
    - Use the value of `PageData.Layout` to select the template for execution. If the layout is not specified in the frontmatter or the `PageData.Layout` field is empty, it defaults to `base.html`.
- Added an example `layouts/post.html` to demonstrate the new feature.
- Updated `content/hello.md` to use the new `post.html` layout.

This change provides greater flexibility in defining the structure and appearance of different types of content across the site.